### PR TITLE
サーバサイドのリファクタ

### DIFF
--- a/game_server/internal/domain/chat.go
+++ b/game_server/internal/domain/chat.go
@@ -1,0 +1,15 @@
+package domain
+
+type Chat struct {
+	From string `json:"from"`
+	Id   string `json:"id"`
+	Text string `json:"text"`
+}
+
+func (c *Chat) Clone() *Chat {
+	return &Chat{
+		From: c.From,
+		Id:   c.Id,
+		Text: c.Text,
+	}
+}

--- a/game_server/internal/domain/game.go
+++ b/game_server/internal/domain/game.go
@@ -32,12 +32,10 @@ func (g *Game) Clone() *Game {
 	ng := &Game{
 		ID:      g.ID,
 		Players: map[string]Player{},
-		Board:   [8][8]Color{},
+		Board:   g.Board,
 		Turn:    g.Turn,
 		Status:  g.Status,
 	}
-	ng.Board = g.Board
-
 	// playerの情報を書き換えられないように値コピーする
 	for k, v := range g.Players {
 		ng.Players[k] = v

--- a/game_server/internal/infrastructure/memoryRepo.go
+++ b/game_server/internal/infrastructure/memoryRepo.go
@@ -9,30 +9,41 @@ import (
 type IMemoryRepository interface {
 	SaveGame(game *domain.Game) error
 	GetGame(gameId string) *domain.Game
+	SaveChats(gameId string, chat *domain.Chat) error
+	GetChats(gameId string) []*domain.Chat
+}
+
+type IMemoryRepositoryOnlySave interface {
+	SaveGame(game *domain.Game) error
 }
 
 type MemoryRepository struct {
-	mu    sync.RWMutex
 	games map[string]*domain.Game
+	chats map[string][]*domain.Chat
+	mu    sync.RWMutex
 }
 
 func NewMemoryRepository() IMemoryRepository {
-	return &MemoryRepository{games: map[string]*domain.Game{}}
+	return &MemoryRepository{
+		games: make(map[string]*domain.Game),
+		chats: make(map[string][]*domain.Chat),
+	}
 }
 
 // ゲームの状態が変更されたら実行される
 func (mr *MemoryRepository) SaveGame(game *domain.Game) error {
 	mr.mu.Lock()
+	defer mr.mu.Unlock()
 	if game != nil && mr.games[game.ID] != nil {
 		return errors.New("game is nil or game whitch you have saved is already saved")
 	}
 	mr.games[game.ID] = game
-	mr.mu.Unlock()
 	return nil
 }
 
 func (mr *MemoryRepository) GetGame(gameId string) *domain.Game {
 	mr.mu.Lock()
+	defer mr.mu.Unlock()
 	if gameId == "" {
 		return nil
 	}
@@ -40,6 +51,40 @@ func (mr *MemoryRepository) GetGame(gameId string) *domain.Game {
 	if !ok {
 		return nil
 	}
-	mr.mu.Unlock()
 	return g.Clone()
+}
+
+func (mr *MemoryRepository) SaveChats(gameId string, chat *domain.Chat) error {
+	if chat == nil {
+		return errors.New("chat is nil")
+	}
+	mr.mu.Lock()
+	defer mr.mu.Unlock()
+	// gameIdに紐づいたチャット一覧がなければスライスを作成する
+	if mr.chats[gameId] == nil {
+		mr.chats[gameId] = make([]*domain.Chat, 0)
+	}
+
+	// gameIdで指定したマッチのチャット一覧を取得し、新しいチャットを保存する
+	chats := mr.chats[gameId]
+	chats = append(chats, chat)
+	mr.chats[gameId] = chats
+	return nil
+}
+
+func (mr *MemoryRepository) GetChats(gameId string) []*domain.Chat {
+	mr.mu.RLock()
+	defer mr.mu.RUnlock()
+	if gameId == "" {
+		return nil
+	}
+	// gameIdに紐づいたチャット一覧を取得
+	// 一覧を返す
+	chats, ok := mr.chats[gameId]
+	if !ok {
+		return nil
+	}
+	cloneChats := make([]*domain.Chat, 0)
+	cloneChats = append(cloneChats, chats...)
+	return cloneChats
 }

--- a/game_server/internal/infrastructure/memoryRepo.go
+++ b/game_server/internal/infrastructure/memoryRepo.go
@@ -1,0 +1,45 @@
+package infra
+
+import (
+	"errors"
+	"othello_game_go/internal/domain"
+	"sync"
+)
+
+type IMemoryRepository interface {
+	SaveGame(game *domain.Game) error
+	GetGame(gameId string) *domain.Game
+}
+
+type MemoryRepository struct {
+	mu    sync.RWMutex
+	games map[string]*domain.Game
+}
+
+func NewMemoryRepository() IMemoryRepository {
+	return &MemoryRepository{games: map[string]*domain.Game{}}
+}
+
+// ゲームの状態が変更されたら実行される
+func (mr *MemoryRepository) SaveGame(game *domain.Game) error {
+	mr.mu.Lock()
+	if game != nil && mr.games[game.ID] != nil {
+		return errors.New("game is nil or game whitch you have saved is already saved")
+	}
+	mr.games[game.ID] = game
+	mr.mu.Unlock()
+	return nil
+}
+
+func (mr *MemoryRepository) GetGame(gameId string) *domain.Game {
+	mr.mu.Lock()
+	if gameId == "" {
+		return nil
+	}
+	g, ok := mr.games[gameId]
+	if !ok {
+		return nil
+	}
+	mr.mu.Unlock()
+	return g.Clone()
+}

--- a/game_server/internal/infrastructure/persist.go
+++ b/game_server/internal/infrastructure/persist.go
@@ -1,0 +1,31 @@
+package infra
+
+import (
+	"othello_game_go/internal/domain"
+)
+
+type PersistType int
+
+const (
+	PersistGame PersistType = iota
+	PersistChat
+	PersistGameAndChats
+)
+
+// レポジトリに保存するデータオブジェクトの構造体
+type PersistRequest struct {
+	Type  PersistType // 保存するオブジェクトを指定
+	Game  *domain.Game
+	Chat  *domain.Chat
+	Chats []*domain.Chat
+
+	Ack chan error // nilなら非同期を表す
+}
+
+type IPersistor interface {
+	// EnqueuePersist はリクエストを永続化キューへ入れる（非ブロッキングを推奨）
+	// 戻り値:
+	//   true  -> 正常にキューへ入れた
+	//   false -> キューが満杯などで enqueuing に失敗（呼び出し側はログ/バックプレッシャを取る）
+	EnqueuePersist(req *PersistRequest) bool
+}

--- a/game_server/internal/presentation/handler.go
+++ b/game_server/internal/presentation/handler.go
@@ -1,6 +1,7 @@
 package presentation
 
 import (
+	"log"
 	"net/http"
 	"othello_game_go/internal/dto"
 	"othello_game_go/internal/usecase"
@@ -73,36 +74,36 @@ func (rh *GameRequestHandler) JoinGame(ctx *gin.Context) {
 
 // オセロを動かす処理のエンドポイント
 func (rh *GameRequestHandler) MoveOthello(ctx *gin.Context) {
-	// gameId := ctx.Param("gameId")
-	// if gameId == "" {
-	// 	log.Print("game id require")
-	// 	ctx.JSON(http.StatusBadRequest, gin.H{"error": "gameID is required"})
-	// 	return
-	// }
-	// var input dto.MoveOthelloInput
-	// err := ctx.ShouldBindJSON(&input)
-	// if err != nil {
-	// 	log.Print("err should bind")
-	// 	ctx.JSON(http.StatusBadRequest, gin.H{"error": "gameID is required"})
-	// 	return
-	// }
+	gameId := ctx.Param("gameId")
+	if gameId == "" {
+		log.Print("game id require")
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": "gameID is required"})
+		return
+	}
+	var input dto.MoveOthelloInput
+	err := ctx.ShouldBindJSON(&input)
+	if err != nil {
+		log.Print("err should bind")
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": "gameID is required"})
+		return
+	}
 
-	// ch := make(chan usecase.Reply, 1)
-	// cm := &usecase.MoveCommand{
-	// 	GameId:   gameId,
-	// 	PlayerId: input.PlayerId,
-	// 	X:        input.X,
-	// 	Y:        input.Y,
-	// 	Reply:    ch,
-	// }
-	// rh.match.ExecuteCommand(cm)
+	ch := make(chan usecase.Reply, 1)
+	cm := &usecase.MoveCommand{
+		GameId:   gameId,
+		PlayerId: input.PlayerId,
+		X:        input.X,
+		Y:        input.Y,
+		Reply:    ch,
+	}
+	rh.matchManeger.ExecuteCommand(gameId, cm)
 
-	// result := <-cm.Reply
-	// if result.Err != nil {
-	// 	ctx.JSON(http.StatusInternalServerError, gin.H{"error": result.Err.Error()})
-	// 	return
-	// }
-	// ctx.JSON(http.StatusOK, gin.H{"move gid": gameId, "move pid": input.PlayerId, "X": input.X, "Y": input.Y})
+	result := <-cm.Reply
+	if result.Err != nil {
+		ctx.JSON(http.StatusInternalServerError, gin.H{"error": result.Err.Error()})
+		return
+	}
+	ctx.JSON(http.StatusOK, gin.H{"move gid": gameId, "move pid": input.PlayerId, "X": input.X, "Y": input.Y})
 }
 
 func (rh *GameRequestHandler) GetGameState(ctx *gin.Context) {

--- a/game_server/internal/presentation/handler.go
+++ b/game_server/internal/presentation/handler.go
@@ -1,9 +1,7 @@
 package presentation
 
 import (
-	"log"
 	"net/http"
-	"othello_game_go/internal/domain"
 	"othello_game_go/internal/dto"
 	"othello_game_go/internal/usecase"
 
@@ -18,11 +16,11 @@ type IGameRequestHandler interface {
 }
 
 type GameRequestHandler struct {
-	match usecase.IGameMatch
+	matchManeger usecase.IGameMatchManeger
 }
 
-func NewGameRequestHandler(match usecase.IGameMatch) IGameRequestHandler {
-	return &GameRequestHandler{match: match}
+func NewGameRequestHandler(matchManeger usecase.IGameMatchManeger) IGameRequestHandler {
+	return &GameRequestHandler{matchManeger: matchManeger}
 }
 
 func (rh *GameRequestHandler) CreateGame(ctx *gin.Context) {
@@ -32,87 +30,94 @@ func (rh *GameRequestHandler) CreateGame(ctx *gin.Context) {
 		ctx.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
-	gameid, playerid, err := rh.match.CreateMatch(input.Player)
+	// ゲームマッチを作成し、エラーが無ければマッチを開始 = gameloopを開始してリクエストを受け付ける
+	gameId, playerId, err := rh.matchManeger.CreateGameMatch(input.Player)
 	if err != nil {
 		ctx.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
-	ctx.JSON(http.StatusOK, gin.H{"gameid": gameid, "playerid": playerid})
+	err = rh.matchManeger.StartGameMatch(gameId)
+	if err != nil {
+		ctx.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	ctx.JSON(http.StatusOK, gin.H{"gameid": gameId, "playerid": playerId})
 }
 
 func (rh *GameRequestHandler) JoinGame(ctx *gin.Context) {
-	input := dto.CreateGameInput{}
-	err := ctx.ShouldBindJSON(&input)
-	if err != nil {
-		ctx.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
-		return
-	}
-	gameId := ctx.Param("gameId")
+	// input := dto.CreateGameInput{}
+	// err := ctx.ShouldBindJSON(&input)
+	// if err != nil {
+	// 	ctx.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+	// 	return
+	// }
+	// gameId := ctx.Param("gameId")
 
-	ch := make(chan usecase.Reply, 1)
-	cm := &usecase.JoinCommand{
-		GameId:     gameId,
-		PlayerName: input.Player,
-		Reply:      ch,
-	}
-	rh.match.ExecuteCommand(cm)
-	result := <-cm.Reply
-	if result.Err != nil {
-		if result.Err.Error() == "game match not exist" {
-			ctx.JSON(http.StatusInternalServerError, gin.H{"error": result.Err.Error()})
-			return
-		}
-	}
-	ctx.JSON(http.StatusOK, gin.H{"gameId": gameId, "playerId": result.Result})
+	// ch := make(chan usecase.Reply, 1)
+	// cm := &usecase.JoinCommand{
+	// 	GameId:     gameId,
+	// 	PlayerName: input.Player,
+	// 	Reply:      ch,
+	// }
+	// rh.match.ExecuteCommand(cm)
+	// result := <-cm.Reply
+	// if result.Err != nil {
+	// 	if result.Err.Error() == "game match not exist" {
+	// 		ctx.JSON(http.StatusInternalServerError, gin.H{"error": result.Err.Error()})
+	// 		return
+	// 	}
+	// }
+	// ctx.JSON(http.StatusOK, gin.H{"gameId": gameId, "playerId": result.Result})
 }
 
 // オセロを動かす処理のエンドポイント
 func (rh *GameRequestHandler) MoveOthello(ctx *gin.Context) {
-	gameId := ctx.Param("gameId")
-	if gameId == "" {
-		log.Print("game id require")
-		ctx.JSON(http.StatusBadRequest, gin.H{"error": "gameID is required"})
-		return
-	}
-	var input dto.MoveOthelloInput
-	err := ctx.ShouldBindJSON(&input)
-	if err != nil {
-		log.Print("err should bind")
-		ctx.JSON(http.StatusBadRequest, gin.H{"error": "gameID is required"})
-		return
-	}
+	// gameId := ctx.Param("gameId")
+	// if gameId == "" {
+	// 	log.Print("game id require")
+	// 	ctx.JSON(http.StatusBadRequest, gin.H{"error": "gameID is required"})
+	// 	return
+	// }
+	// var input dto.MoveOthelloInput
+	// err := ctx.ShouldBindJSON(&input)
+	// if err != nil {
+	// 	log.Print("err should bind")
+	// 	ctx.JSON(http.StatusBadRequest, gin.H{"error": "gameID is required"})
+	// 	return
+	// }
 
-	ch := make(chan usecase.Reply, 1)
-	cm := &usecase.MoveCommand{
-		GameId:   gameId,
-		PlayerId: input.PlayerId,
-		X:        input.X,
-		Y:        input.Y,
-		Reply:    ch,
-	}
-	rh.match.ExecuteCommand(cm)
+	// ch := make(chan usecase.Reply, 1)
+	// cm := &usecase.MoveCommand{
+	// 	GameId:   gameId,
+	// 	PlayerId: input.PlayerId,
+	// 	X:        input.X,
+	// 	Y:        input.Y,
+	// 	Reply:    ch,
+	// }
+	// rh.match.ExecuteCommand(cm)
 
-	result := <-cm.Reply
-	if result.Err != nil {
-		ctx.JSON(http.StatusInternalServerError, gin.H{"error": result.Err.Error()})
-		return
-	}
-	ctx.JSON(http.StatusOK, gin.H{"move gid": gameId, "move pid": input.PlayerId, "X": input.X, "Y": input.Y})
+	// result := <-cm.Reply
+	// if result.Err != nil {
+	// 	ctx.JSON(http.StatusInternalServerError, gin.H{"error": result.Err.Error()})
+	// 	return
+	// }
+	// ctx.JSON(http.StatusOK, gin.H{"move gid": gameId, "move pid": input.PlayerId, "X": input.X, "Y": input.Y})
 }
 
 func (rh *GameRequestHandler) GetGameState(ctx *gin.Context) {
-	gameId := ctx.Param("gameId")
+	// gameId := ctx.Param("gameId")
 
-	ch := make(chan *domain.Game, 1)
-	cm := &usecase.StateRequest{
-		GameId: gameId,
-		Reply:  ch,
-	}
-	rh.match.ExecuteCommand(cm)
-	result := <-cm.Reply
-	if result == nil {
-		ctx.JSON(http.StatusInternalServerError, gin.H{"error": "game not exist"})
-		return
-	}
-	ctx.JSON(http.StatusOK, gin.H{"join_game gid": result})
+	// ch := make(chan *domain.Game, 1)
+	// cm := &usecase.StateRequest{
+	// 	GameId: gameId,
+	// 	Reply:  ch,
+	// }
+	// rh.match.ExecuteCommand(cm)
+	// result := <-cm.Reply
+	// if result == nil {
+	// 	ctx.JSON(http.StatusInternalServerError, gin.H{"error": "game not exist"})
+	// 	return
+	// }
+	// ctx.JSON(http.StatusOK, gin.H{"join_game gid": result})
 }

--- a/game_server/internal/presentation/handler.go
+++ b/game_server/internal/presentation/handler.go
@@ -46,29 +46,29 @@ func (rh *GameRequestHandler) CreateGame(ctx *gin.Context) {
 }
 
 func (rh *GameRequestHandler) JoinGame(ctx *gin.Context) {
-	// input := dto.CreateGameInput{}
-	// err := ctx.ShouldBindJSON(&input)
-	// if err != nil {
-	// 	ctx.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
-	// 	return
-	// }
-	// gameId := ctx.Param("gameId")
+	input := dto.CreateGameInput{}
+	err := ctx.ShouldBindJSON(&input)
+	if err != nil {
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	gameId := ctx.Param("gameId")
 
-	// ch := make(chan usecase.Reply, 1)
-	// cm := &usecase.JoinCommand{
-	// 	GameId:     gameId,
-	// 	PlayerName: input.Player,
-	// 	Reply:      ch,
-	// }
-	// rh.match.ExecuteCommand(cm)
-	// result := <-cm.Reply
-	// if result.Err != nil {
-	// 	if result.Err.Error() == "game match not exist" {
-	// 		ctx.JSON(http.StatusInternalServerError, gin.H{"error": result.Err.Error()})
-	// 		return
-	// 	}
-	// }
-	// ctx.JSON(http.StatusOK, gin.H{"gameId": gameId, "playerId": result.Result})
+	ch := make(chan usecase.Reply, 1)
+	cm := &usecase.JoinCommand{
+		GameId:     gameId,
+		PlayerName: input.Player,
+		Reply:      ch,
+	}
+	rh.matchManeger.ExecuteCommand(gameId, cm)
+	result := <-cm.Reply
+	if result.Err != nil {
+		if result.Err.Error() == "game match not exist" {
+			ctx.JSON(http.StatusInternalServerError, gin.H{"error": result.Err.Error()})
+			return
+		}
+	}
+	ctx.JSON(http.StatusOK, gin.H{"gameId": gameId, "playerId": result.Result})
 }
 
 // オセロを動かす処理のエンドポイント

--- a/game_server/internal/presentation/handler.go
+++ b/game_server/internal/presentation/handler.go
@@ -3,6 +3,7 @@ package presentation
 import (
 	"log"
 	"net/http"
+	"othello_game_go/internal/domain"
 	"othello_game_go/internal/dto"
 	"othello_game_go/internal/usecase"
 
@@ -14,6 +15,7 @@ type IGameRequestHandler interface {
 	JoinGame(ctx *gin.Context)
 	MoveOthello(ctx *gin.Context)
 	GetGameState(ctx *gin.Context)
+	GetChats(ctx *gin.Context)
 }
 
 type GameRequestHandler struct {
@@ -104,6 +106,36 @@ func (rh *GameRequestHandler) MoveOthello(ctx *gin.Context) {
 		return
 	}
 	ctx.JSON(http.StatusOK, gin.H{"move gid": gameId, "move pid": input.PlayerId, "X": input.X, "Y": input.Y})
+}
+
+func (rh *GameRequestHandler) GetChats(ctx *gin.Context) {
+	gameId := ctx.Param("gameId")
+	if gameId == "" {
+		log.Print("game id require")
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": "gameId is required"})
+		return
+	}
+
+	// var input dto.GetChatsInput
+	// err := ctx.BindJSON(input)
+	// if err != nil {
+	// 	log.Print("err should bind")
+	// 	ctx.JSON(http.StatusBadRequest, gin.H{"error": "gameID is required"})
+	// 	return
+	// }
+
+	// とってきたチャットをどうやってクライアントに戻すか
+	chats := rh.matchManeger.GetChats(gameId)
+	if chats == nil {
+		ctx.JSON(http.StatusInternalServerError, gin.H{"error": "chats is exist"})
+		return
+	}
+	chatsSlice := make([]domain.Chat, 0)
+	for _, chat := range chats {
+		chatsSlice = append(chatsSlice, *chat)
+	}
+	ctx.JSON(http.StatusOK, chatsSlice)
+
 }
 
 func (rh *GameRequestHandler) GetGameState(ctx *gin.Context) {

--- a/game_server/internal/presentation/handler.go
+++ b/game_server/internal/presentation/handler.go
@@ -127,7 +127,7 @@ func (rh *GameRequestHandler) GetChats(ctx *gin.Context) {
 	// とってきたチャットをどうやってクライアントに戻すか
 	chats := rh.matchManeger.GetChats(gameId)
 	if chats == nil {
-		ctx.JSON(http.StatusInternalServerError, gin.H{"error": "chats is exist"})
+		ctx.JSON(http.StatusInternalServerError, gin.H{"error": "chats not exist"})
 		return
 	}
 	chatsSlice := make([]domain.Chat, 0)

--- a/game_server/internal/presentation/websocketHub.go
+++ b/game_server/internal/presentation/websocketHub.go
@@ -31,11 +31,6 @@ func (ws *WebsocketHandler) ServeWS(ctx *gin.Context) {
 		ctx.JSON(http.StatusBadRequest, gin.H{"error": "gameId is required"})
 		return
 	}
-	gameMatch := ws.matchManeger.GetMatch(gameId)
-	if gameMatch == nil {
-		ctx.JSON(http.StatusInternalServerError, gin.H{"error": "gameMatch not exist"})
-		return
-	}
 	// HTTP接続をWebsocketにアップグレードする
 	conn, err := ws.upgrader.Upgrade(ctx.Writer, ctx.Request, nil)
 	if err != nil {

--- a/game_server/internal/presentation/websocketHub.go
+++ b/game_server/internal/presentation/websocketHub.go
@@ -141,15 +141,19 @@ func (ws *WebsocketHandler) ServeWS(ctx *gin.Context) {
 				switch t {
 				case "chat":
 					var event usecase.Event
+					var chat domain.Chat
 					if from, ok := m["from"].(string); ok {
 						if text, ok := m["text"].(string); ok {
 							if id, ok := m["id"].(string); ok {
 								event = usecase.Event{Event: t, Payload: map[string]string{"id": id, "from": from, "text": text}}
+								chat = domain.Chat{From: from, Id: id, Text: text}
 							}
 						}
 					}
 					// マッチマネージャーを介して、メッセージを送信する
 					ws.matchManeger.PublishEvent(gameId, event)
+					// チャットをリポジトリに保存する
+					ws.matchManeger.SaveChats(gameId, chat)
 				default:
 
 				}

--- a/game_server/internal/presentation/websocketHub.go
+++ b/game_server/internal/presentation/websocketHub.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"othello_game_go/internal/domain"
 	"othello_game_go/internal/usecase"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/gorilla/websocket"
@@ -44,30 +45,127 @@ func (ws *WebsocketHandler) ServeWS(ctx *gin.Context) {
 		return
 	}
 
-	defer func() {
-		ws.matchManeger.RemoveSubscribe(gameId, subscribedCh)
-		close(*subscribedCh)
-		conn.Close()
+	// writePumpの処理
+	// Websocketで同期対象のクライアントに対するメッセージの
+	// 書き込み処理を一か所に集約させる
+	// sendChに同期するイベントメッセージを送信する
+	sendCh := make(chan []byte, 128)
+
+	go func() {
+		ticker := time.NewTicker(5 * time.Second)
+		defer func() {
+			ticker.Stop()
+			conn.Close()
+		}()
+
+		for {
+			// sendChからメッセージを取り出す
+			select {
+			case b, ok := <-sendCh:
+				if !ok {
+					// sendChが閉じられた場合の分岐となる
+					conn.WriteMessage(websocket.CloseMessage, []byte{})
+					return
+				}
+
+				// 10秒以上の書き込みは停止する
+				// 書き込みが長時間ブロックして処理が止まることを防ぐ
+				conn.SetWriteDeadline(time.Now().Add(10 * time.Second))
+				if err := conn.WriteMessage(websocket.TextMessage, b); err != nil {
+					log.Println("writePump: write error", err)
+					return
+				}
+				// pingを送る
+			case <-ticker.C:
+				log.Println("writePump: ticker")
+				conn.SetWriteDeadline(time.Now().Add(10 * time.Second))
+				if err := conn.WriteMessage(websocket.PingMessage, nil); err != nil {
+					log.Println("writePump: write error", err)
+					return
+				}
+			}
+		}
 	}()
 
+	forwardDone := make(chan struct{})
+	// usecase層からのイベントメッセージを受け取り、writePumpに渡す
+	go func() {
+		defer close(forwardDone)
+		// usecase層からのチャネルに対するデータの送信をポーリングし続ける
+		for ev := range *subscribedCh {
+			log.Printf("serveWS: %v", ev)
+			// JSON にエンコードして送る。小さな最適化のために json.Marshal を使っている
+			b, _ := json.Marshal(ev)
+			select {
+			// writePumpにデータを送る
+			case sendCh <- b:
+			default:
+				log.Println("sendCh full, dropping event for conn")
+			}
+		}
+	}()
+
+	// 初回にゲーム参加時のゲームの状態を同期する
 	rc := make(chan *domain.Game, 1)
 	ws.matchManeger.ExecuteCommand(gameId, &usecase.StateRequest{GameId: gameId, Reply: rc})
 	if gameinfo := <-rc; gameinfo != nil {
 		log.Println("serveWS gameinfo")
 		log.Printf("serveWS: %v", gameinfo)
-		conn.WriteJSON(map[string]any{"type": "state", "payload": *gameinfo.Clone()})
-	}
-
-	// usecase層からのチャネルに対するデータの送信をポーリングし続ける
-	for ev := range *subscribedCh {
-		log.Printf("serveWS: %v", ev)
-		// JSON にエンコードして送る。小さな最適化のために json.Marshal を使っている
-		b, _ := json.Marshal(ev)
-		// WriteMessage を使って TextMessage を送信する。
-		// ここでエラーが起きたら（接続切断など）、writer を抜けて接続をクローズする
-		if err := conn.WriteMessage(websocket.TextMessage, b); err != nil {
-			log.Println("ws write err:", err)
-			return
+		b, _ := json.Marshal(map[string]any{"type": "state", "payload": *gameinfo.Clone()})
+		select {
+		case sendCh <- b:
+		default:
+			log.Println("sendCh full, dropping event for conn")
 		}
 	}
+
+	// readPump クライアントからの受信処理を行う(現時点では未実装)
+	// 受け取ったデータをゲームマッチに送信する
+	conn.SetReadLimit(512 << 10)
+	conn.SetReadDeadline(time.Now().Add(60 * time.Second))
+	conn.SetPongHandler(func(string) error {
+		conn.SetReadDeadline(time.Now().Add(60 * time.Second))
+		return nil
+	})
+	go func() {
+		defer func() {
+			close(sendCh)
+		}()
+		for {
+			var m map[string]any
+			// クライアントから来たリクエストを読み取る
+			if err := conn.ReadJSON(&m); err != nil {
+				return
+			}
+			if t, ok := m["type"].(string); ok {
+				switch t {
+				case "chat":
+					var event usecase.Event
+					if from, ok := m["from"].(string); ok {
+						if text, ok := m["text"].(string); ok {
+							if id, ok := m["id"].(string); ok {
+								event = usecase.Event{Event: t, Payload: map[string]string{"id": id, "from": from, "text": text}}
+							}
+						}
+					}
+					// マッチマネージャーを介して、メッセージを送信する
+					ws.matchManeger.PublishEvent(gameId, event)
+				default:
+
+				}
+			}
+		}
+	}()
+
+	// forwardDoneに値が送信されて受信するか、
+	// このチャネルが閉じられるまでここでブロックする
+	// 受信した場合は、受信データは読み捨てる。
+	// 今回は閉じられるまでブロックする設計になっている
+	<-forwardDone
+	// 関数終了時に、以下を終了させる
+	// マッチ側からのメッセージ受信チャネル、Websocket通信
+	ws.matchManeger.RemoveSubscribe(gameId, subscribedCh)
+	close(*subscribedCh)
+	// conn.Close() writepumpのdeferでクローズする
+
 }

--- a/game_server/internal/presentation/websocketHub.go
+++ b/game_server/internal/presentation/websocketHub.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"net/http"
 	"othello_game_go/internal/domain"
+	infra "othello_game_go/internal/infrastructure"
 	"othello_game_go/internal/usecase"
 	"time"
 
@@ -17,11 +18,21 @@ type IWebsocketHandler interface {
 }
 
 type WebsocketHandler struct {
-	matchManeger usecase.IGameMatchManeger
+	matchManeger IWebSocketManager
 	upgrader     websocket.Upgrader
 }
 
-func NewWebsocketHandler(matchManeger usecase.IGameMatchManeger) IWebsocketHandler {
+type IWebSocketManager interface {
+	SetSubscribe(gameId string) (*chan usecase.Event, error)
+	RemoveSubscribe(gameId string, evCh *chan usecase.Event) error
+	ExecuteCommand(gameId string, command usecase.ICommand) error
+	GetMatch(gameId string) *usecase.GameMatch
+	PublishEvent(gameId string, event usecase.Event) error
+	GetChats(gameId string) []*domain.Chat
+	EnqueuePersist(req *infra.PersistRequest) bool
+}
+
+func NewWebsocketHandler(matchManeger IWebSocketManager) IWebsocketHandler {
 	return &WebsocketHandler{matchManeger: matchManeger}
 }
 
@@ -106,12 +117,35 @@ func (ws *WebsocketHandler) ServeWS(ctx *gin.Context) {
 	}()
 
 	// 初回にゲーム参加時のゲームの状態を同期する
+	// おそらくバグっている
+	// クライアント側は、まずJoinリクエストを送ってからWebsocket通信を確立するので、
+	// Join時にGame状態をWebsocket通信で送っても受け取れず盤面が表示されない
+	// そのため、Websocket通信を確立した時点でゲーム状態を同期する必要がある
 	rc := make(chan *domain.Game, 1)
 	ws.matchManeger.ExecuteCommand(gameId, &usecase.StateRequest{GameId: gameId, Reply: rc})
 	if gameinfo := <-rc; gameinfo != nil {
 		log.Println("serveWS gameinfo")
 		log.Printf("serveWS: %v", gameinfo)
 		b, _ := json.Marshal(map[string]any{"type": "state", "payload": *gameinfo.Clone()})
+
+		select {
+		case sendCh <- b:
+		default:
+			log.Println("sendCh full, dropping event for conn")
+		}
+	}
+	// 初回にチャット履歴を同期する
+	chats := ws.matchManeger.GetChats(gameId)
+	if chats != nil {
+		chatsSlice := make([]domain.Chat, 0)
+		for _, chat := range chats {
+			if chat != nil {
+				chatsSlice = append(chatsSlice, *chat.Clone())
+			}
+		}
+		chatsHistory := make(map[string][]domain.Chat)
+		chatsHistory["chats_history"] = chatsSlice
+		b, _ := json.Marshal(map[string]any{"type": "chats_history", "payload": chatsHistory})
 		select {
 		case sendCh <- b:
 		default:
@@ -153,7 +187,14 @@ func (ws *WebsocketHandler) ServeWS(ctx *gin.Context) {
 					// マッチマネージャーを介して、メッセージを送信する
 					ws.matchManeger.PublishEvent(gameId, event)
 					// チャットをリポジトリに保存する
-					ws.matchManeger.SaveChats(gameId, chat)
+					req := &infra.PersistRequest{
+						Type:  infra.PersistChat,
+						Game:  &domain.Game{ID: gameId},
+						Chat:  &chat,
+						Chats: nil,
+					}
+					// チャットを非同期で保存
+					ws.matchManeger.EnqueuePersist(req)
 				default:
 
 				}

--- a/game_server/internal/usecase/game_match.go
+++ b/game_server/internal/usecase/game_match.go
@@ -172,26 +172,22 @@ func (m *GameMatch) gameLoop(id string) {
 			game["game"] = m.gameinfo.Clone()
 			m.broadcast(Event{Event: "state", Payload: game})
 		// オセロを動かす分岐
-		// case *MoveCommand:
-		// 	if match, ok := m.gameinfo[c.GameId]; !ok {
-		// 		c.Reply <- Reply{Err: errors.New("game match not exist")}
-		// 	} else {
-		// 		c.Match = match
-		// 		// オセロを動かす処理の実行
-		// 		c.execute()
-		// 		// クライアントにオセロの移動情報とゲームの状態を同期する
-		// 		m.broadcast(Event{Event: "move",
-		// 			Payload: map[string]any{
-		// 				"player_id": c.PlayerId,
-		// 				"x":         c.X,
-		// 				"y":         c.Y,
-		// 			}})
-		// 		log.Printf("game loop board: %v", *m.gameinfo[id].Clone())
-		// 		m.broadcast(Event{Event: "state",
-		// 			Payload: *m.gameinfo[id].Clone(),
-		// 		})
-		// 		c.Reply <- Reply{Err: nil}
-		// 	}
+		case *MoveCommand:
+			c.Match = m.gameinfo
+			// オセロを動かす処理の実行
+			c.execute()
+			// クライアントにオセロの移動情報とゲームの状態を同期する
+			// m.broadcast(Event{Event: "move",
+			// 	Payload: map[string]any{
+			// 		"player_id": c.PlayerId,
+			// 		"x":         c.X,
+			// 		"y":         c.Y,
+			// 	}})
+			// log.Printf("game loop board: %v", *m.gameinfo.Clone())
+			// m.broadcast(Event{Event: "state",
+			// 	Payload: *m.gameinfo.Clone(),
+			// })
+			c.Reply <- Reply{Err: nil}
 		// case *StateRequest:
 		// 	log.Printf("state request gameloop: %v", m.gameinfo[id].Clone())
 		// 	c.Reply <- m.gameinfo[id].Clone()

--- a/game_server/internal/usecase/game_match.go
+++ b/game_server/internal/usecase/game_match.go
@@ -11,7 +11,7 @@ import (
 )
 
 type IGameMatch interface {
-	ExecuteCommand(command ICommand)
+	GameLoop(id string)
 	Subscribe(ch chan Event)
 	UnSubscribe(ch chan Event)
 }
@@ -158,7 +158,7 @@ func (m *GameMatch) broadcast(e Event) {
 	}
 }
 
-func (m *GameMatch) gameLoop(id string) {
+func (m *GameMatch) GameLoop(id string) {
 	for {
 		// TODO コマンドが増えたら実装
 		//select {
@@ -195,10 +195,6 @@ func (m *GameMatch) gameLoop(id string) {
 		}
 		log.Printf("game looping session id : %s\n", m.gameinfo.ID)
 	}
-}
-
-func (m *GameMatch) ExecuteCommand(command ICommand) {
-
 }
 
 // ランダムなIDを生成する

--- a/game_server/internal/usecase/game_match.go
+++ b/game_server/internal/usecase/game_match.go
@@ -12,7 +12,6 @@ import (
 
 type IGameMatch interface {
 	ExecuteCommand(command ICommand)
-	GetMatch(gameId string) *domain.Game
 	Subscribe(ch chan Event)
 	UnSubscribe(ch chan Event)
 }
@@ -177,20 +176,20 @@ func (m *GameMatch) gameLoop(id string) {
 			// オセロを動かす処理の実行
 			c.execute()
 			// クライアントにオセロの移動情報とゲームの状態を同期する
-			// m.broadcast(Event{Event: "move",
-			// 	Payload: map[string]any{
-			// 		"player_id": c.PlayerId,
-			// 		"x":         c.X,
-			// 		"y":         c.Y,
-			// 	}})
-			// log.Printf("game loop board: %v", *m.gameinfo.Clone())
-			// m.broadcast(Event{Event: "state",
-			// 	Payload: *m.gameinfo.Clone(),
-			// })
+			m.broadcast(Event{Event: "move",
+				Payload: map[string]any{
+					"player_id": c.PlayerId,
+					"x":         c.X,
+					"y":         c.Y,
+				}})
+			log.Printf("game loop board: %v", *m.gameinfo.Clone())
+			m.broadcast(Event{Event: "state",
+				Payload: *m.gameinfo.Clone(),
+			})
 			c.Reply <- Reply{Err: nil}
-		// case *StateRequest:
-		// 	log.Printf("state request gameloop: %v", m.gameinfo[id].Clone())
-		// 	c.Reply <- m.gameinfo[id].Clone()
+		case *StateRequest:
+			log.Printf("state request gameloop: %v", m.gameinfo.Clone())
+			c.Reply <- m.gameinfo.Clone()
 		default:
 			log.Printf("game looping default")
 		}
@@ -200,15 +199,6 @@ func (m *GameMatch) gameLoop(id string) {
 
 func (m *GameMatch) ExecuteCommand(command ICommand) {
 
-}
-
-func (m *GameMatch) GetMatch(gameId string) *domain.Game {
-	// g, ok := m.gameinfo[gameId]
-	// if !ok {
-	// 	return nil
-	// }
-	// return g
-	return &domain.Game{}
 }
 
 // ランダムなIDを生成する

--- a/game_server/internal/usecase/game_match.go
+++ b/game_server/internal/usecase/game_match.go
@@ -160,81 +160,50 @@ func (m *GameMatch) broadcast(e Event) {
 }
 
 func (m *GameMatch) gameLoop(id string) {
-	// for {
-	// 	// TODO コマンドが増えたら実装
-	// 	//select {
-	// 	cmd := <-m.cmd
-	// 	switch c := cmd.(type) {
-	// 	case *JoinCommand:
-	// 		if match, ok := m.gameinfo[c.GameId]; !ok {
-	// 			c.Reply <- Reply{Err: errors.New("game match not exist")}
-	// 		} else {
-	// 			c.Match = match
-	// 			c.execute()
-	// 			game := make(map[string]*domain.Game)
-	// 			game["game"] = m.gameinfo[id].Clone()
-	// 			m.broadcast(Event{Event: "state", Payload: game})
-	// 		}
-	// 	// オセロを動かす分岐
-	// 	case *MoveCommand:
-	// 		if match, ok := m.gameinfo[c.GameId]; !ok {
-	// 			c.Reply <- Reply{Err: errors.New("game match not exist")}
-	// 		} else {
-	// 			c.Match = match
-	// 			// オセロを動かす処理の実行
-	// 			c.execute()
-	// 			// クライアントにオセロの移動情報とゲームの状態を同期する
-	// 			m.broadcast(Event{Event: "move",
-	// 				Payload: map[string]any{
-	// 					"player_id": c.PlayerId,
-	// 					"x":         c.X,
-	// 					"y":         c.Y,
-	// 				}})
-	// 			log.Printf("game loop board: %v", *m.gameinfo[id].Clone())
-	// 			m.broadcast(Event{Event: "state",
-	// 				Payload: *m.gameinfo[id].Clone(),
-	// 			})
-	// 			c.Reply <- Reply{Err: nil}
-	// 		}
-	// 	case *StateRequest:
-	// 		log.Printf("state request gameloop: %v", m.gameinfo[id].Clone())
-	// 		c.Reply <- m.gameinfo[id].Clone()
-	// 	default:
-	// 		log.Printf("game looping default")
-	// 	}
-	// 	log.Printf("game looping session id : %s\n", m.gameinfo[id].ID)
-	// }
-	log.Printf("game looping default")
+	for {
+		// TODO コマンドが増えたら実装
+		//select {
+		cmd := <-m.cmd
+		switch c := cmd.(type) {
+		case *JoinCommand:
+			c.Match = m.gameinfo
+			c.execute()
+			game := make(map[string]*domain.Game)
+			game["game"] = m.gameinfo.Clone()
+			m.broadcast(Event{Event: "state", Payload: game})
+		// オセロを動かす分岐
+		// case *MoveCommand:
+		// 	if match, ok := m.gameinfo[c.GameId]; !ok {
+		// 		c.Reply <- Reply{Err: errors.New("game match not exist")}
+		// 	} else {
+		// 		c.Match = match
+		// 		// オセロを動かす処理の実行
+		// 		c.execute()
+		// 		// クライアントにオセロの移動情報とゲームの状態を同期する
+		// 		m.broadcast(Event{Event: "move",
+		// 			Payload: map[string]any{
+		// 				"player_id": c.PlayerId,
+		// 				"x":         c.X,
+		// 				"y":         c.Y,
+		// 			}})
+		// 		log.Printf("game loop board: %v", *m.gameinfo[id].Clone())
+		// 		m.broadcast(Event{Event: "state",
+		// 			Payload: *m.gameinfo[id].Clone(),
+		// 		})
+		// 		c.Reply <- Reply{Err: nil}
+		// 	}
+		// case *StateRequest:
+		// 	log.Printf("state request gameloop: %v", m.gameinfo[id].Clone())
+		// 	c.Reply <- m.gameinfo[id].Clone()
+		default:
+			log.Printf("game looping default")
+		}
+		log.Printf("game looping session id : %s\n", m.gameinfo.ID)
+	}
 }
 
 func (m *GameMatch) ExecuteCommand(command ICommand) {
-	// switch c := command.(type) {
-	// case *JoinCommand:
-	// 	if v, ok := m.cmd[c.GameId]; !ok {
-	// 		c.Reply <- Reply{Err: errors.New("game match not exist")}
 
-	// 	} else {
-	// 		v <- c
-	// 	}
-	// case *MoveCommand:
-	// 	if v, ok := m.cmd[c.GameId]; !ok {
-	// 		c.Reply <- Reply{Err: errors.New("game match not exist")}
-	// 	} else {
-	// 		v <- c
-	// 	}
-	// case *StateRequest:
-	// 	if v, ok := m.cmd[c.GameId]; !ok {
-	// 		log.Println("state request nil")
-	// 		c.Reply <- nil
-
-	// 	} else {
-	// 		log.Println("state request else")
-	// 		v <- c
-
-	// 	}
-	// default:
-	// 	log.Println("execute command default")
-	// }
 }
 
 func (m *GameMatch) GetMatch(gameId string) *domain.Game {

--- a/game_server/internal/usecase/game_match.go
+++ b/game_server/internal/usecase/game_match.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"log"
 	"othello_game_go/internal/domain"
+	infra "othello_game_go/internal/infrastructure"
 	"strconv"
 	"sync"
 )
@@ -23,6 +24,7 @@ type ICommand interface {
 
 type GameMatch struct {
 	gameinfo    *domain.Game
+	repo        infra.IMemoryRepository
 	cmd         chan ICommand
 	mutex       sync.Mutex
 	subscribers []chan Event
@@ -38,8 +40,11 @@ type Reply struct {
 	Err    error
 }
 
-func NewGameMatch(gInfo *domain.Game) IGameMatch {
-	return &GameMatch{gameinfo: gInfo, cmd: make(chan ICommand)}
+func NewGameMatch(gInfo *domain.Game, repo infra.IMemoryRepository) IGameMatch {
+	return &GameMatch{
+		gameinfo: gInfo,
+		repo:     repo,
+		cmd:      make(chan ICommand)}
 }
 
 type JoinCommand struct {

--- a/game_server/internal/usecase/game_match.go
+++ b/game_server/internal/usecase/game_match.go
@@ -24,7 +24,7 @@ type ICommand interface {
 
 type GameMatch struct {
 	gameinfo    *domain.Game
-	repo        infra.IMemoryRepository
+	repo        infra.IMemoryRepositoryOnlySave
 	cmd         chan ICommand
 	mutex       sync.Mutex
 	subscribers []chan Event
@@ -40,7 +40,7 @@ type Reply struct {
 	Err    error
 }
 
-func NewGameMatch(gInfo *domain.Game, repo infra.IMemoryRepository) IGameMatch {
+func NewGameMatch(gInfo *domain.Game, repo infra.IMemoryRepositoryOnlySave) IGameMatch {
 	return &GameMatch{
 		gameinfo: gInfo,
 		repo:     repo,
@@ -130,6 +130,9 @@ func (mc *MoveCommand) execute() {
 	}(mc.Match, p.ID)
 }
 
+type GetChatsCommand struct {
+}
+
 func (m *GameMatch) Subscribe(ch chan Event) {
 	m.mutex.Lock()
 	m.subscribers = append(m.subscribers, ch)
@@ -177,6 +180,7 @@ func (m *GameMatch) GameLoop(id string) {
 		case *JoinCommand:
 			c.Match = m.gameinfo
 			c.execute()
+			m.repo.SaveGame(m.gameinfo)
 			game := make(map[string]*domain.Game)
 			game["game"] = m.gameinfo.Clone()
 			m.broadcast(Event{Event: "state", Payload: game})
@@ -185,6 +189,7 @@ func (m *GameMatch) GameLoop(id string) {
 			c.Match = m.gameinfo
 			// オセロを動かす処理の実行
 			c.execute()
+			m.repo.SaveGame(m.gameinfo)
 			// クライアントにオセロの移動情報とゲームの状態を同期する
 			m.broadcast(Event{Event: "move",
 				Payload: map[string]any{

--- a/game_server/internal/usecase/game_match.go
+++ b/game_server/internal/usecase/game_match.go
@@ -14,6 +14,7 @@ type IGameMatch interface {
 	GameLoop(id string)
 	Subscribe(ch chan Event)
 	UnSubscribe(ch chan Event)
+	PublishEvent(e Event)
 }
 
 type ICommand interface {
@@ -156,6 +157,10 @@ func (m *GameMatch) broadcast(e Event) {
 		default:
 		}
 	}
+}
+
+func (m *GameMatch) PublishEvent(e Event) {
+	m.broadcast(e)
 }
 
 func (m *GameMatch) GameLoop(id string) {

--- a/game_server/internal/usecase/game_match.go
+++ b/game_server/internal/usecase/game_match.go
@@ -4,11 +4,13 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"errors"
+	"fmt"
 	"log"
 	"othello_game_go/internal/domain"
 	infra "othello_game_go/internal/infrastructure"
 	"strconv"
 	"sync"
+	"time"
 )
 
 type IGameMatch interface {
@@ -16,6 +18,8 @@ type IGameMatch interface {
 	Subscribe(ch chan Event)
 	UnSubscribe(ch chan Event)
 	PublishEvent(e Event)
+	NotifyPersistAsync(req *infra.PersistRequest)
+	NotifyPersistSync(req *infra.PersistRequest, timeout time.Duration) error
 }
 
 type ICommand interface {
@@ -24,7 +28,7 @@ type ICommand interface {
 
 type GameMatch struct {
 	gameinfo    *domain.Game
-	repo        infra.IMemoryRepositoryOnlySave
+	repo        infra.IPersistor
 	cmd         chan ICommand
 	mutex       sync.Mutex
 	subscribers []chan Event
@@ -40,7 +44,7 @@ type Reply struct {
 	Err    error
 }
 
-func NewGameMatch(gInfo *domain.Game, repo infra.IMemoryRepositoryOnlySave) IGameMatch {
+func NewGameMatch(gInfo *domain.Game, repo infra.IPersistor) IGameMatch {
 	return &GameMatch{
 		gameinfo: gInfo,
 		repo:     repo,
@@ -180,16 +184,32 @@ func (m *GameMatch) GameLoop(id string) {
 		case *JoinCommand:
 			c.Match = m.gameinfo
 			c.execute()
-			m.repo.SaveGame(m.gameinfo)
-			game := make(map[string]*domain.Game)
-			game["game"] = m.gameinfo.Clone()
-			m.broadcast(Event{Event: "state", Payload: game})
-		// オセロを動かす分岐
+
+			// ゲーム状態を保存する
+			req := &infra.PersistRequest{
+				Type: infra.PersistGame,
+				Game: m.gameinfo.Clone(),
+				Ack:  nil,
+			}
+			m.NotifyPersistAsync(req)
+
+			// ゲーム状態を他クライアントへ同期してもらう
+			// game := make(map[string]*domain.Game)
+			// game["game"] = m.gameinfo.Clone()
+			// m.broadcast(Event{Event: "state", Payload: *m.gameinfo.Clone()}) // オセロを動かす分岐
 		case *MoveCommand:
 			c.Match = m.gameinfo
 			// オセロを動かす処理の実行
 			c.execute()
-			m.repo.SaveGame(m.gameinfo)
+
+			// ゲーム状態を保存する
+			req := &infra.PersistRequest{
+				Type: infra.PersistGame,
+				Game: m.gameinfo.Clone(),
+				Ack:  nil,
+			}
+			m.NotifyPersistAsync(req)
+
 			// クライアントにオセロの移動情報とゲームの状態を同期する
 			m.broadcast(Event{Event: "move",
 				Payload: map[string]any{
@@ -209,6 +229,28 @@ func (m *GameMatch) GameLoop(id string) {
 			log.Printf("game looping default")
 		}
 		log.Printf("game looping session id : %s\n", m.gameinfo.ID)
+	}
+}
+
+func (m *GameMatch) NotifyPersistAsync(req *infra.PersistRequest) {
+	if !m.repo.EnqueuePersist(req) {
+		log.Printf("persist queue full; dropping persit request for", m.gameinfo.ID)
+	}
+}
+
+func (m *GameMatch) NotifyPersistSync(req *infra.PersistRequest, timeout time.Duration) error {
+	if !m.repo.EnqueuePersist(req) {
+		log.Printf("persist queue full; dropping persit request for", m.gameinfo.ID)
+		return fmt.Errorf("persist queue full")
+	}
+
+	// 同期でエラー変数の返却を待機して、呼び出し元に処理結果を伝える
+	select {
+	case err := <-req.Ack:
+		return err
+	// もしタイムアウト時間を過ぎたらエラーを返す
+	case <-time.After(timeout):
+		return fmt.Errorf("persist ack timeout")
 	}
 }
 

--- a/game_server/internal/usecase/game_match_maneger.go
+++ b/game_server/internal/usecase/game_match_maneger.go
@@ -1,0 +1,87 @@
+package usecase
+
+import (
+	"errors"
+	"log"
+	"othello_game_go/internal/domain"
+)
+
+type IGameMatchManeger interface {
+	CreateGameMatch(playerName string) (playerId, gameId string, err error)
+	StartGameMatch(gameId string) error
+	ExecuteCommand(gameId string, command ICommand)
+}
+
+type GameMatchManeger struct {
+	gameMatches map[string]*GameMatch
+}
+
+func NewGameMatchManeger() IGameMatchManeger {
+	return &GameMatchManeger{gameMatches: make(map[string]*GameMatch)}
+}
+
+func (gm *GameMatchManeger) ExecuteCommand(gameId string, command ICommand) {
+
+}
+
+func (gm *GameMatchManeger) CreateGameMatch(playerName string) (playerId, gameId string, err error) {
+
+	gameInfo, pId := gm.createGameInfo(playerName)
+	gameMatch := NewGameMatch(gameInfo)
+	if err := gm.addGameMatch(gameMatch); err != nil {
+		return "", "", err
+	}
+
+	log.Printf("Create Match for : %s\n", playerName)
+
+	return gameInfo.ID, pId, nil
+}
+
+// ゲームマッチを開始し、リクエストを受け付ける
+func (gm *GameMatchManeger) StartGameMatch(gameId string) error {
+
+	if match, ok := gm.gameMatches[gameId]; !ok {
+		return errors.New("not exist game match")
+	} else {
+		go match.gameLoop(gameId)
+		return nil
+	}
+}
+
+// ゲームの状態構造体を作成する
+func (gm *GameMatchManeger) createGameInfo(playerName string) (*domain.Game, string) {
+
+	gameinfo := domain.Game{
+		ID:      "g" + RandomID(8),
+		Players: map[string]domain.Player{},
+		Status:  "Waiting",
+	}
+	pId := "p" + RandomID(8)
+	gameinfo.Players[pId] = domain.Player{
+		ID:    pId,
+		Name:  playerName,
+		Color: domain.Black,
+	}
+	gameinfo.Turn = pId
+	gameinfo.Board[3][3], gameinfo.Board[4][4] = domain.White, domain.White
+	gameinfo.Board[3][4], gameinfo.Board[4][3] = domain.Black, domain.Black
+
+	return &gameinfo, pId
+}
+
+func (gm *GameMatchManeger) addGameMatch(match IGameMatch) error {
+	switch m := match.(type) {
+	case *GameMatch:
+		if m.gameinfo.ID == "" {
+			return errors.New("not exist game id")
+		}
+		if _, ok := gm.gameMatches[m.gameinfo.ID]; ok {
+			return errors.New("already exist game match")
+		}
+
+		gm.gameMatches[m.gameinfo.ID] = m
+		return nil
+	default:
+		return errors.New("not exist kind og IGameMatch Interface")
+	}
+}

--- a/game_server/internal/usecase/game_match_maneger.go
+++ b/game_server/internal/usecase/game_match_maneger.go
@@ -9,7 +9,7 @@ import (
 type IGameMatchManeger interface {
 	CreateGameMatch(playerName string) (playerId, gameId string, err error)
 	StartGameMatch(gameId string) error
-	ExecuteCommand(gameId string, command ICommand)
+	ExecuteCommand(gameId string, command ICommand) error
 }
 
 type GameMatchManeger struct {
@@ -20,8 +20,13 @@ func NewGameMatchManeger() IGameMatchManeger {
 	return &GameMatchManeger{gameMatches: make(map[string]*GameMatch)}
 }
 
-func (gm *GameMatchManeger) ExecuteCommand(gameId string, command ICommand) {
-
+func (gm *GameMatchManeger) ExecuteCommand(gameId string, command ICommand) error {
+	if match, ok := gm.gameMatches[gameId]; !ok {
+		return errors.New("not exist game match")
+	} else {
+		match.cmd <- command
+		return nil
+	}
 }
 
 func (gm *GameMatchManeger) CreateGameMatch(playerName string) (playerId, gameId string, err error) {

--- a/game_server/internal/usecase/game_match_maneger.go
+++ b/game_server/internal/usecase/game_match_maneger.go
@@ -10,6 +10,7 @@ type IGameMatchManeger interface {
 	CreateGameMatch(playerName string) (playerId, gameId string, err error)
 	StartGameMatch(gameId string) error
 	ExecuteCommand(gameId string, command ICommand) error
+	GetMatch(gameId string) *GameMatch
 }
 
 type GameMatchManeger struct {
@@ -51,6 +52,14 @@ func (gm *GameMatchManeger) StartGameMatch(gameId string) error {
 		go match.gameLoop(gameId)
 		return nil
 	}
+}
+
+func (gm *GameMatchManeger) GetMatch(gameId string) *GameMatch {
+	g, ok := gm.gameMatches[gameId]
+	if !ok {
+		return nil
+	}
+	return g
 }
 
 // ゲームの状態構造体を作成する

--- a/game_server/internal/usecase/game_match_maneger.go
+++ b/game_server/internal/usecase/game_match_maneger.go
@@ -16,6 +16,8 @@ type IGameMatchManeger interface {
 	ExecuteCommand(gameId string, command ICommand) error
 	GetMatch(gameId string) *GameMatch
 	PublishEvent(gameId string, event Event) error
+	SaveChats(gameId string, chat domain.Chat) error
+	GetChats(gameId string) []*domain.Chat
 }
 
 type GameMatchManeger struct {
@@ -70,11 +72,11 @@ func (gm *GameMatchManeger) StartGameMatch(gameId string) error {
 
 func (gm *GameMatchManeger) GetMatch(gameId string) *GameMatch {
 	gm.mu.RLock()
-	defer gm.mu.RUnlock()
 	g, ok := gm.gameMatches[gameId]
 	if !ok {
 		return nil
 	}
+	gm.mu.RUnlock()
 	return g
 }
 
@@ -111,6 +113,22 @@ func (gm *GameMatchManeger) PublishEvent(gameId string, event Event) error {
 		match.PublishEvent(event)
 		return nil
 	}
+}
+
+func (gm *GameMatchManeger) SaveChats(gameId string, chat domain.Chat) error {
+	match := gm.GetMatch(gameId)
+	if match == nil {
+		return nil
+	}
+	return gm.repo.SaveChats(gameId, &chat)
+}
+
+func (gm *GameMatchManeger) GetChats(gameId string) []*domain.Chat {
+	match := gm.GetMatch(gameId)
+	if match == nil {
+		return nil
+	}
+	return gm.repo.GetChats(gameId)
 }
 
 // ゲームの状態構造体を作成する

--- a/game_server/internal/usecase/game_match_maneger.go
+++ b/game_server/internal/usecase/game_match_maneger.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"log"
 	"othello_game_go/internal/domain"
+	infra "othello_game_go/internal/infrastructure"
 	"sync"
 )
 
@@ -19,11 +20,15 @@ type IGameMatchManeger interface {
 
 type GameMatchManeger struct {
 	gameMatches map[string]*GameMatch
+	repo        infra.IMemoryRepository
 	mu          sync.RWMutex
 }
 
-func NewGameMatchManeger() IGameMatchManeger {
-	return &GameMatchManeger{gameMatches: make(map[string]*GameMatch)}
+func NewGameMatchManeger(repo infra.IMemoryRepository) IGameMatchManeger {
+	return &GameMatchManeger{
+		gameMatches: make(map[string]*GameMatch),
+		repo:        repo,
+	}
 }
 
 func (gm *GameMatchManeger) ExecuteCommand(gameId string, command ICommand) error {
@@ -39,10 +44,12 @@ func (gm *GameMatchManeger) ExecuteCommand(gameId string, command ICommand) erro
 
 func (gm *GameMatchManeger) CreateGameMatch(playerName string) (gameId, playerId string, err error) {
 	gameInfo, pId := gm.createGameInfo(playerName)
-	gameMatch := NewGameMatch(gameInfo)
+	gameMatch := NewGameMatch(gameInfo, gm.repo)
 	if err := gm.addGameMatch(gameMatch); err != nil {
 		return "", "", err
 	}
+
+	gm.repo.SaveGame(gameInfo)
 
 	log.Printf("Create Match for : %s\n", playerName)
 
@@ -127,6 +134,7 @@ func (gm *GameMatchManeger) createGameInfo(playerName string) (*domain.Game, str
 	return &gameinfo, pId
 }
 
+// 作成したGameMatchをマネージャーの管理するスライスに保存する
 func (gm *GameMatchManeger) addGameMatch(match IGameMatch) error {
 	switch m := match.(type) {
 	case *GameMatch:

--- a/game_server/internal/usecase/game_match_maneger.go
+++ b/game_server/internal/usecase/game_match_maneger.go
@@ -14,6 +14,7 @@ type IGameMatchManeger interface {
 	RemoveSubscribe(gameId string, evCh *chan Event) error
 	ExecuteCommand(gameId string, command ICommand) error
 	GetMatch(gameId string) *GameMatch
+	PublishEvent(gameId string, event Event) error
 }
 
 type GameMatchManeger struct {
@@ -90,6 +91,17 @@ func (gm *GameMatchManeger) RemoveSubscribe(gameId string, evCh *chan Event) err
 	} else {
 		evCh := make(chan Event, 128)
 		match.UnSubscribe(evCh)
+		return nil
+	}
+}
+
+func (gm *GameMatchManeger) PublishEvent(gameId string, event Event) error {
+	gm.mu.RLock()
+	defer gm.mu.RUnlock()
+	if match, ok := gm.gameMatches[gameId]; !ok {
+		return errors.New("not exist game match")
+	} else {
+		match.PublishEvent(event)
 		return nil
 	}
 }

--- a/game_server/internal/usecase/game_match_maneger.go
+++ b/game_server/internal/usecase/game_match_maneger.go
@@ -6,6 +6,7 @@ import (
 	"othello_game_go/internal/domain"
 	infra "othello_game_go/internal/infrastructure"
 	"sync"
+	"time"
 )
 
 type IGameMatchManeger interface {
@@ -18,19 +19,29 @@ type IGameMatchManeger interface {
 	PublishEvent(gameId string, event Event) error
 	SaveChats(gameId string, chat domain.Chat) error
 	GetChats(gameId string) []*domain.Chat
+	EnqueuePersist(req *infra.PersistRequest) bool
+	persistWorker(workerID int)
+	handlePersistWithRetry(req *infra.PersistRequest) error
+	handlePersistOnce(req *infra.PersistRequest) error
 }
 
 type GameMatchManeger struct {
 	gameMatches map[string]*GameMatch
 	repo        infra.IMemoryRepository
+	persistCh   chan *infra.PersistRequest
+	stopCh      chan struct{}
 	mu          sync.RWMutex
 }
 
 func NewGameMatchManeger(repo infra.IMemoryRepository) IGameMatchManeger {
-	return &GameMatchManeger{
+	gm := &GameMatchManeger{
 		gameMatches: make(map[string]*GameMatch),
 		repo:        repo,
+		persistCh:   make(chan *infra.PersistRequest, 8192),
+		stopCh:      make(chan struct{}),
 	}
+	go gm.persistWorker(1)
+	return gm
 }
 
 func (gm *GameMatchManeger) ExecuteCommand(gameId string, command ICommand) error {
@@ -46,7 +57,10 @@ func (gm *GameMatchManeger) ExecuteCommand(gameId string, command ICommand) erro
 
 func (gm *GameMatchManeger) CreateGameMatch(playerName string) (gameId, playerId string, err error) {
 	gameInfo, pId := gm.createGameInfo(playerName)
-	gameMatch := NewGameMatch(gameInfo, gm.repo)
+	// MatchManegerにDBの保存リクエストを受け取る関数を実装している
+	// GameMatchには、その関数のみを定義したinterfaceをメンバーに持っているので
+	// 引数としてMangerを渡せる。かつManegerの他の関数は使えないので疎結合になる
+	gameMatch := NewGameMatch(gameInfo, gm)
 	if err := gm.addGameMatch(gameMatch); err != nil {
 		return "", "", err
 	}
@@ -168,5 +182,103 @@ func (gm *GameMatchManeger) addGameMatch(match IGameMatch) error {
 		return nil
 	default:
 		return errors.New("not exist kind og IGameMatch Interface")
+	}
+}
+
+/*
+* レポジトリへの永続化関連の処理
+ */
+
+// persitチャンネルに保存リクエストを送信する
+func (gs *GameMatchManeger) EnqueuePersist(req *infra.PersistRequest) bool {
+	select {
+	case gs.persistCh <- req:
+		return true
+	// persistChが満杯で受け取れない場合は、falseを返す
+	default:
+		return false
+	}
+}
+
+func (gs *GameMatchManeger) persistWorker(workerID int) {
+
+	for {
+		select {
+		// persistチャンネルから保存リクエストを取り出す
+		case req := <-gs.persistCh:
+			// nilの場合は、先頭に戻ってまたチャンネルにリクエストが送られることを待機する
+			if req == nil {
+				continue
+			}
+			// 保存リクエストを実行する
+			err := gs.handlePersistWithRetry(req)
+			// nilでなければ同期処理を表すので、err変数を返却する
+			if req.Ack != nil {
+				select {
+				case req.Ack <- err:
+				default:
+				}
+			}
+
+		case <-gs.stopCh:
+			return
+		}
+	}
+}
+
+func (gs *GameMatchManeger) handlePersistWithRetry(req *infra.PersistRequest) error {
+
+	// 最大リトライ回数
+	maxAttemps := 3
+	// エラー変数
+	var err error
+	// リトライ間隔
+	backOff := 50 * time.Millisecond
+	// リトライ回数分DBへの保存を試行する
+	for attempt := 1; attempt <= maxAttemps; attempt++ {
+		err = gs.handlePersistOnce(req)
+		// 成功すればnilを返して正常終了
+		if err == nil {
+			return nil
+		}
+		// errの場合はリトライ間隔分待機する
+		time.Sleep(backOff)
+		// 指数的バックオフなので、リトライ間隔を2倍する
+		backOff *= 2
+	}
+
+	// forを抜けてしまったら、errを返す
+	log.Printf("persist failed after retries: %v", err)
+	return err
+
+}
+
+func (gs *GameMatchManeger) handlePersistOnce(req *infra.PersistRequest) error {
+	switch req.Type {
+	case infra.PersistGame:
+		return gs.repo.SaveGame(req.Game)
+
+	case infra.PersistChat:
+		return gs.repo.SaveChats(req.Game.ID, req.Chat)
+
+	case infra.PersistGameAndChats:
+
+		// Game状態の保存
+		if req.Game != nil {
+			if err := gs.repo.SaveGame(req.Game); err != nil {
+				return err
+			}
+		}
+
+		// 複数チャットの保存
+		for _, chat := range req.Chats {
+			if err := gs.repo.SaveChats(req.Game.ID, chat); err != nil {
+				return err
+			}
+		}
+		return nil
+
+	default:
+		return nil
 	}
 }

--- a/game_server/main.go
+++ b/game_server/main.go
@@ -8,9 +8,9 @@ import (
 )
 
 func main() {
-	gameMath := usecase.NewGameMatchManeger()
-	gameRequestHandler := presentation.NewGameRequestHandler(gameMath)
-	websocket := presentation.NewWebsocketHandler(gameMath)
+	gameMatchManeger := usecase.NewGameMatchManeger()
+	gameRequestHandler := presentation.NewGameRequestHandler(gameMatchManeger)
+	websocket := presentation.NewWebsocketHandler(gameMatchManeger)
 	r := gin.Default()
 
 	r.POST("/create", gameRequestHandler.CreateGame)

--- a/game_server/main.go
+++ b/game_server/main.go
@@ -8,15 +8,15 @@ import (
 )
 
 func main() {
-	gameMath := usecase.NewGameMatch()
+	gameMath := usecase.NewGameMatchManeger()
 	gameRequestHandler := presentation.NewGameRequestHandler(gameMath)
-	websocket := presentation.NewWebsocketHandler(gameMath)
+	//websocket := presentation.NewWebsocketHandler(gameMath)
 	r := gin.Default()
 
 	r.POST("/create", gameRequestHandler.CreateGame)
 	r.POST(":gameId/join", gameRequestHandler.JoinGame)
 	r.POST("move/:gameId", gameRequestHandler.MoveOthello)
-	r.GET(":gameId/ws", websocket.ServeWS)
+	//r.GET(":gameId/ws", websocket.ServeWS)
 	r.GET("/getstate/:gameId", gameRequestHandler.GetGameState)
 
 	r.Run()

--- a/game_server/main.go
+++ b/game_server/main.go
@@ -10,13 +10,13 @@ import (
 func main() {
 	gameMath := usecase.NewGameMatchManeger()
 	gameRequestHandler := presentation.NewGameRequestHandler(gameMath)
-	//websocket := presentation.NewWebsocketHandler(gameMath)
+	websocket := presentation.NewWebsocketHandler(gameMath)
 	r := gin.Default()
 
 	r.POST("/create", gameRequestHandler.CreateGame)
 	r.POST(":gameId/join", gameRequestHandler.JoinGame)
 	r.POST("move/:gameId", gameRequestHandler.MoveOthello)
-	//r.GET(":gameId/ws", websocket.ServeWS)
+	r.GET(":gameId/ws", websocket.ServeWS)
 	r.GET("/getstate/:gameId", gameRequestHandler.GetGameState)
 
 	r.Run()

--- a/game_server/main.go
+++ b/game_server/main.go
@@ -18,6 +18,7 @@ func main() {
 	r.POST("/create", gameRequestHandler.CreateGame)
 	r.POST(":gameId/join", gameRequestHandler.JoinGame)
 	r.POST("move/:gameId", gameRequestHandler.MoveOthello)
+	// クライアント起動した時にリクエストがクライアントから飛ばされる
 	r.GET(":gameId/ws", websocket.ServeWS)
 	r.GET("/getstate/:gameId", gameRequestHandler.GetGameState)
 	r.GET("/getChats/:gameId", gameRequestHandler.GetChats)

--- a/game_server/main.go
+++ b/game_server/main.go
@@ -20,6 +20,7 @@ func main() {
 	r.POST("move/:gameId", gameRequestHandler.MoveOthello)
 	r.GET(":gameId/ws", websocket.ServeWS)
 	r.GET("/getstate/:gameId", gameRequestHandler.GetGameState)
+	r.GET("/getChats/:gameId", gameRequestHandler.GetChats)
 
 	r.Run()
 }

--- a/game_server/main.go
+++ b/game_server/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	infra "othello_game_go/internal/infrastructure"
 	"othello_game_go/internal/presentation"
 	"othello_game_go/internal/usecase"
 
@@ -8,7 +9,8 @@ import (
 )
 
 func main() {
-	gameMatchManeger := usecase.NewGameMatchManeger()
+	gameRepository := infra.NewMemoryRepository()
+	gameMatchManeger := usecase.NewGameMatchManeger(gameRepository)
 	gameRequestHandler := presentation.NewGameRequestHandler(gameMatchManeger)
 	websocket := presentation.NewWebsocketHandler(gameMatchManeger)
 	r := gin.Default()


### PR DESCRIPTION
　GameMatchManegerの実装
　　GameMatchの管理をするマネージャークラス
　　GameMatchの作成とmatchに対してのコマンド実行を行う
　CreateMatchのリファクタ
　　Manegerでmatchを作成し、Manegerのマップに保持する
　　Matchのゲームループを開始させる
　マネージャーを介して、マッチを操作する構造にするので、一旦ほかの関数をコメントアウトする